### PR TITLE
Add skip macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ end
 
 ```
 
+Or you can use the `skip` macro (suggested by [@sgtFloyd](https://github.com/sgtFloyd)):
+
+```ruby
+skip def test_something
+  # ...
+end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/minitest/skip_dsl.rb
+++ b/lib/minitest/skip_dsl.rb
@@ -59,3 +59,10 @@ module Kernel
 
   private :xdescribe
 end
+
+class Minitest::Runnable
+  def self.skip(method_name)
+    undef_method(method_name)
+    define_method("skip_#{method_name}") {}
+  end
+end

--- a/test/test_skip_dsl.rb
+++ b/test/test_skip_dsl.rb
@@ -53,4 +53,21 @@ class TestSkipDSL < Minitest::Test
 
     assert_includes @output.string.dup, "4 runs, 1 assertions, 0 failures, 0 errors, 3 skips"
   end
+
+  def test_skip_macro
+    test = describe "Test" do
+      skip def test_something
+        assert false
+      end
+
+      def test_something_else
+        assert false
+      end
+      skip :test_something_else
+    end
+    test.run(@reporter)
+    @reporter.report
+
+    assert_includes @output.string.dup, "2 runs, 0 assertions, 0 failures, 0 errors, 2 skips"
+  end
 end


### PR DESCRIPTION
Adds `skip` macro, originally suggested by @sgtFloyd
