### PR TITLE
skip macro needs require

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or install it yourself as:
 
     $ gem install minitest-skip
 
-And that's it! This is a Minitest plugin which means that it will be autoloaded. If you want to use `xit` and `xdescribe` methods, you also need to `require "minitest/skip_dsl"`.
+And that's it! This is a Minitest plugin which means that it will be autoloaded. If you want to use `xit` and `xdescribe` methods or the `skip` macro, you also need to `require 'minitest/skip_dsl'`.
 
 ## Contributing
 


### PR DESCRIPTION
`skip_` method prefix works with Minitest plugin auto-loading but the `skip` macro requires to require the dsl plugin to work.